### PR TITLE
Support certain (older?) buildpacks

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -10,10 +10,12 @@ else
 	fi
 fi
 
-build_root=/tmp/source
+app_dir=/app
+build_root=/tmp/build
 cache_root=/tmp/cache
 buildpack_root=/tmp/buildpacks
 
+mkdir -p $app_dir
 mkdir -p $cache_root
 mkdir -p $buildpack_root
 mkdir -p $build_root/.profile.d
@@ -47,12 +49,17 @@ function ensure_indent() {
 
 ## Load source from STDIN
 
-cat | tar -xC $build_root
+cat | tar -xC $app_dir
+
+# In heroku, there are two separate directories, and some
+# buildpacks expect that.
+cp -r $app_dir/. $build_root
 
 ## Buildpack fixes
 
 export REQUEST_ID=$(openssl rand -base64 32)
-mkdir /app
+export APP_DIR="$app_dir"
+export HOME="$app_dir"
 
 ## Buildpack detection
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -100,8 +100,11 @@ if [[ -f "$build_root/Procfile" ]]; then
 	types=$(ruby -e "require 'yaml';puts YAML.load_file('$build_root/Procfile').keys().join(', ')")
 	echo_normal "Procfile declares types -> $types"
 fi
-default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
-[[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
+default_types=""
+if [[ -s "$build_root/.release" ]]; then
+	default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
+	[[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
+fi
 
 
 ## Produce slug


### PR DESCRIPTION
I was trying to use https://github.com/localmed/heroku-buildpack-python-extras which is based off of an older version of the Python buildpack, and there are a couple of issues:
1. I am running into the same issue as https://github.com/progrium/buildstep/pull/4 (Heroku has separate directories for $APP_DIR and build root, and the buildpack expects that). So I've ported the buildstep patch to extract to a different directory and copy to the build dir.
2. As a related problem - slugbuilder does not set the `$APP_DIR` variable (not sure if it is a real thing, I didn't find any info on it), which makes the buildpack assume `$HOME` by default, and in the slugbuilder environment, `$HOME` appears to be /). The patch sets both `$APP_DIR` and `$HOME` to the location the tarball is extracted to.
3. Finally, the buildpack release script doesn't generate any output (in some cases), so the `.release` file is empty, which the script could't handle. This is also fixed.
