### PR TITLE
Use custom or multiple buildpacks easily

### DIFF
--- a/builder/buildpacks.txt
+++ b/builder/buildpacks.txt
@@ -1,3 +1,4 @@
+https://github.com/ddollar/heroku-buildpack-multi.git
 https://github.com/heroku/heroku-buildpack-ruby.git
 https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-java.git


### PR DESCRIPTION
A simple alternative approach to avoid environment variables by just adding a .buildpacks with one or more buildpacks to your git push.
