### PR TITLE
feat(slugbuilder): run slugbuilder as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM progrium/cedarish
 MAINTAINER progrium "progrium@gmail.com"
 
+RUN useradd slugbuilder --home-dir /app
+
+# allow user RW access to /app
+RUN mkdir /app
+RUN chown -R slugbuilder:slugbuilder /app
+
 ADD ./builder/ /tmp/builder
 RUN mkdir -p /tmp/buildpacks && cd /tmp/buildpacks && xargs -L 1 git clone --depth=1 < /tmp/builder/buildpacks.txt
 ENTRYPOINT ["/tmp/builder/build.sh"]
+USER slugbuilder

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -57,9 +57,9 @@ cp -r $app_dir/. $build_root
 
 ## Buildpack fixes
 
-export REQUEST_ID=$(openssl rand -base64 32)
 export APP_DIR="$app_dir"
 export HOME="$app_dir"
+export REQUEST_ID=$(openssl rand -base64 32)
 
 ## Buildpack detection
 


### PR DESCRIPTION
This is a security fix as well as a fix for buildpacks that cannot
be run as root.

One small fix had to be made here with openssl. Docker by default
hardcodes $HOME to /, so shifting the export HOME line up before we
call openssl gives openssl write access to $HOME/.rnd.

fixes deis/deis#568
