### PR TITLE
Set the default working dir to /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN chown -R slugbuilder:slugbuilder /app
 ADD ./builder/ /tmp/builder
 RUN xargs -L 1 /tmp/builder/install-buildpack /tmp/buildpacks < /tmp/builder/buildpacks.txt
 ENTRYPOINT ["/tmp/builder/build.sh"]
+WORKDIR /app
 USER slugbuilder


### PR DESCRIPTION
I'm seeing permission denied failures with buildpacks, specifically https://github.com/heroku/heroku-buildpack-scala.git, because we don't start the build in /app where the slugbuilder user has write permissions.
This fixes that.

Signed-off-by: Tom van Neerijnen tom@tomvn.com
